### PR TITLE
Set resource limits on Container level

### DIFF
--- a/openshift/OpenShiftTemplate.yml
+++ b/openshift/OpenShiftTemplate.yml
@@ -72,6 +72,9 @@ objects:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
+          resources:
+            limits:
+              memory: 1Gi                        
     triggers:
     - type: ConfigChange
 - apiVersion: v1


### PR DESCRIPTION
Restrict how much memory the container can consume.

Limit to avoid it overtaking the cluster if the process were to go rogue.

Related to openshiftio/openshift.io#2685