### PR TITLE
Build on RHEL

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,0 +1,12 @@
+FROM prod.registry.devshift.net/osio-prod/base/pcp:latest
+LABEL maintainer "Devtools <devtools@redhat.com>"
+LABEL author "Devtools <devtools@redhat.com>"
+
+ENV VERSION=v1.4.3
+
+RUN curl -L https://github.com/containous/traefik/releases/download/${VERSION}/traefik_linux-amd64 > /usr/local/traefik && chmod +x /usr/local/traefik
+
+EXPOSE 8080
+EXPOSE 8082
+
+ENTRYPOINT ["/usr/local/traefik"]

--- a/openshift/OpenShiftTemplate.yml
+++ b/openshift/OpenShiftTemplate.yml
@@ -41,7 +41,7 @@ objects:
               - key: traefik.toml
                 path: traefik.toml
         containers:
-        - image: registry.devshift.net/fabric8-services/fabric8-admin-proxy:${IMAGE_TAG}
+        - image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: Always
           name: f8adminproxy
           ports:
@@ -98,5 +98,7 @@ objects:
       kind: Service
       name: f8adminproxy
 parameters:
+- name: IMAGE
+  value: registry.devshift.net/fabric8-services/fabric8-admin-proxy
 - name: IMAGE_TAG
   value: latest


### PR DESCRIPTION
Enable build on RHEL if TARGET=rhel.

The cico environment will continue to build the CentOS based container and in a second step it will build and push a RHEL based container. As of now, the CentOS containers will be the ones being deployed to prod-preview and prod.

This PR will remain as a WIP until this PR is merged and validated:
https://github.com/fabric8-services/fabric8-auth/pull/432